### PR TITLE
task/ci: add GitHub Actions to run tests on demand via comment

### DIFF
--- a/.github/workflows/run_tests_on_comment.yml
+++ b/.github/workflows/run_tests_on_comment.yml
@@ -5,12 +5,20 @@ on:
   issue_comment:
     types: [created]           # run on new comment
 
+permissions:
+  issues: write                # needed to comment back
+  contents: read
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      contents: read
+
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request &&
+       (contains(github.event.comment.body, '/test_fe') ||
+        contains(github.event.comment.body, '/test_be') ||
+        contains(github.event.comment.body, '/test_all')))
 
     steps:
       - name: Checkout repository
@@ -21,13 +29,13 @@ jobs:
         run: |
           COMMENT="${{ github.event.comment.body || '' }}"
           if echo "$COMMENT" | grep -q "/test_all"; then
-            echo "run=all" >> $GITHUB_OUTPUT
+            echo "run=all" >> "$GITHUB_OUTPUT"
           elif echo "$COMMENT" | grep -q "/test_fe"; then
-            echo "run=fe" >> $GITHUB_OUTPUT
+            echo "run=fe" >> "$GITHUB_OUTPUT"
           elif echo "$COMMENT" | grep -q "/test_be"; then
-            echo "run=be" >> $GITHUB_OUTPUT
+            echo "run=be" >> "$GITHUB_OUTPUT"
           else
-            echo "run=manual" >> $GITHUB_OUTPUT
+            echo "run=manual" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Node.js
@@ -40,14 +48,14 @@ jobs:
         run: |
           cd client/react-client-app
           npm ci
-          npm run test || exit 1
+          npm test
 
       - name: Run backend tests
         if: ${{ steps.determine.outputs.run == 'be' || steps.determine.outputs.run == 'all' || github.event_name == 'workflow_dispatch' }}
         run: |
           cd server/node-server-app
           npm ci
-          npm test || exit 1
+          npm test
 
       - name: Post result back to PR
         if: ${{ github.event_name == 'issue_comment' }}
@@ -55,11 +63,15 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const runId = process.env.GITHUB_RUN_ID;
-            const conclusion = '✅ Tests completed successfully.';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const result = '${{ job.status }}' === 'success'
+              ? '✅ Tests completed successfully.'
+              : '❌ Tests failed.';
             await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `${conclusion}\nSee run: ${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}`
+              owner,
+              repo,
+              issue_number,
+              body: `${result}\nSee run details: ${runUrl}`
             });


### PR DESCRIPTION
- Adds GitHub Action to automatically run frontend/backend tests when a PR comment contains /test_fe or /test_be.
- Helps validate builds using GitHub free tier runners.
- Related to Issue #26 (Spike: Run tests online).
- Posts results in the PR’s conversation.
