### PR TITLE
fe: signup and login are sending cookie to server

### DIFF
--- a/client/react-client-app/src/net/auth.js
+++ b/client/react-client-app/src/net/auth.js
@@ -1,9 +1,11 @@
 import { CONF } from "./net-conf.js";
 
 function login({ username, password }) {
-    return fetch(`${CONF.SERVER}/login`, {
+    return fetch(`${CONF.SERVER}/${CONF.URLS.LOGIN}`, {
+        credentials: "include",
         method: "POST",
         headers: {
+            "Accept": "application/json",
             "Content-Type": "application/json",
         },
         body: JSON.stringify({ username, password, token: "token" }),
@@ -11,9 +13,11 @@ function login({ username, password }) {
 }
 
 function signup({ username, password }) {
-    return fetch(`${CONF.SERVER}/signup`, {
+    return fetch(`${CONF.SERVER}/${CONF.URLS.SIGNUP}`, {
+        credentials: "include",
         method: "POST",
         headers: {
+            "Accept": "application/json",
             "Content-Type": "application/json",
         },
         body: JSON.stringify({ username, password, token: "token" }),

--- a/client/react-client-app/src/net/net-conf.js
+++ b/client/react-client-app/src/net/net-conf.js
@@ -1,5 +1,9 @@
 const CONF = {
-    SERVER: "//localhost:9006"
+    SERVER: "//localhost:9006",
+    URLS: {
+        LOGIN: "login",
+        SIGNUP: "signup",
+    }
 };
 
 export { CONF };


### PR DESCRIPTION
Refer to #89 

It introduces `credentials: include` for now and it works. Check the issue. But we need to now update the logic properly in the backend so that we generate secure and properly hashed cookies. More about backend implementation: #87 