### PR TITLE
be: add setupDirectories utility and integrate in server.js (#141)

### DIFF
--- a/server/node-server-app/Dockerfile
+++ b/server/node-server-app/Dockerfile
@@ -26,6 +26,11 @@ RUN mkdir -p /usr/src/app/uploads && \
     chown -R node:node /usr/src/app/uploads && \
     chmod -R 755 /usr/src/app/uploads
 
+
+RUN mkdir -p /usr/src/app/certs && \
+    chown -R node:node /usr/src/app/certs && \
+    chmod -R 755 /usr/src/app/certs
+
 ENV NODE_ENV=production
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/server/node-server-app/src/server.js
+++ b/server/node-server-app/src/server.js
@@ -1,6 +1,8 @@
+import { existsSync, mkdirSync } from "node:fs";
+import { resolve as pathResolve } from "node:path";
+
 import express from "express";
 import * as cookieParserPkg from "cookie-parser";
-import path from "node:path";
 
 import { SERVER_PORT } from "./config.js";
 import { setupCorsMiddleware } from "./middlewares/corsMiddleware.js";
@@ -13,13 +15,13 @@ import { setupDirectories } from "./utils/fs.js";
 const app = express();
 const cookieParser = cookieParserPkg.default;
 
-setupDirectories();
+setupDirectories({ exists: existsSync, mkdir: mkdirSync });
 /* Middlewares */
 app.use(express.json());
 app.use(cookieParser());
 setupCorsMiddleware(app);
 
-app.use("/uploads", express.static(path.resolve(process.cwd(), "server/node-server-app/uploads")));
+app.use("/uploads", express.static(pathResolve(process.cwd(), "server/node-server-app/uploads")));
 
 /* Endpoint Handlers */
 setupRootHandlers(app);

--- a/server/node-server-app/src/utils/fs.js
+++ b/server/node-server-app/src/utils/fs.js
@@ -1,22 +1,21 @@
-import fs from "node:fs";
-import path from "node:path";
+
+import { dirname, resolve, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = dirname(__filename);
 
-const ROOT_DIR = path.resolve(__dirname, "../../");
+const ROOT_DIR = resolve(__dirname, "../../");
+const UPLOAD_DIR = join(ROOT_DIR, "uploads");
+const CERTS_DIR = join(ROOT_DIR, "certs");
 
-const UPLOAD_DIR = path.join(ROOT_DIR, "uploads");
-const CERTS_DIR = path.join(ROOT_DIR, "certs");
-
-function setupDirectories() {
+function setupDirectories({ exists, mkdir }) {
     try {
         const directories = [UPLOAD_DIR, CERTS_DIR];
 
         directories.forEach((dir) => {
-            if (!fs.existsSync(dir)) {
-                fs.mkdirSync(dir, { recursive: true });
+            if (!exists(dir)) {
+                mkdir(dir, { recursive: true });
                 console.log(`[setupDirectories] Created directory: ${dir}`);
             }
         });

--- a/server/node-server-app/tests-jest/utils/fs.test.js
+++ b/server/node-server-app/tests-jest/utils/fs.test.js
@@ -1,0 +1,69 @@
+import { UPLOAD_DIR, CERTS_DIR, setupDirectories } from "../../src/utils/fs.js";
+import { test, beforeEach, afterEach, expect, jest } from "@jest/globals";
+
+beforeEach(() => {
+    jest.restoreAllMocks();
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
+test("UPLOAD_DIR and CERTS_DIR end with expected folder names and are distinct", () => {
+    expect(UPLOAD_DIR.split("/").pop()).toBe("uploads");
+    expect(CERTS_DIR.split("/").pop()).toBe("certs");
+    expect(UPLOAD_DIR).not.toBe(CERTS_DIR);
+});
+
+test("setupDirectories creates missing directories and logs creation (both missing)", () => {
+    const exists = jest.fn().mockReturnValue(false);
+    const mkdir = jest.fn();
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    setupDirectories({ exists, mkdir });
+
+    expect(exists).toHaveBeenCalledTimes(2);
+    expect(mkdir).toHaveBeenCalledTimes(2);
+    expect(mkdir).toHaveBeenCalledWith(UPLOAD_DIR, { recursive: true });
+    expect(mkdir).toHaveBeenCalledWith(CERTS_DIR, { recursive: true });
+    expect(logSpy).toHaveBeenCalled();
+    expect(logSpy.mock.calls.some(c => c.join(" ").includes("Created directory"))).toBe(true);
+});
+
+test("setupDirectories creates only the missing directory when one exists", () => {
+    const exists = jest.fn((dir) => dir === UPLOAD_DIR); // UPLOAD_DIR exists, CERTS_DIR missing
+    const mkdir = jest.fn();
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    setupDirectories({ exists, mkdir });
+
+    expect(exists).toHaveBeenCalledTimes(2);
+    expect(mkdir).toHaveBeenCalledTimes(1);
+    expect(mkdir).toHaveBeenCalledWith(CERTS_DIR, { recursive: true });
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0][0]).toContain("[setupDirectories]");
+});
+
+test("setupDirectories does nothing when directories already exist", () => {
+    const exists = jest.fn().mockReturnValue(true);
+    const mkdir = jest.fn();
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    setupDirectories({ exists, mkdir });
+
+    expect(exists).toHaveBeenCalledTimes(2);
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+});
+
+test("setupDirectories logs error and rethrows when mkdir throws", () => {
+    const exists = jest.fn().mockReturnValue(false);
+    const mkdir = jest.fn(() => { throw new Error("Unrelated Error"); });
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => setupDirectories({ exists, mkdir })).toThrow("Unrelated Error");
+    expect(errorSpy).toHaveBeenCalledWith(
+        "[setupDirectories] Error creating directories:",
+        "Unrelated Error"
+    );
+});


### PR DESCRIPTION
closes #141 

- Updated server.js to import and call setupDirectories() before app startup
- Verified correct directory path (directories now created under server/node-server-app/ instead of inside src/utils/)
- To ensure required directories exist before runtime
- preventing file upload and certificate access errors in production and local environments