### PR TITLE
utils/be: add formatted date utility | Closes #142

### DIFF
--- a/server/node-server-app/src/middlewares/uploadMiddleware.js
+++ b/server/node-server-app/src/middlewares/uploadMiddleware.js
@@ -1,6 +1,7 @@
 import multer from "multer";
-import path from "path";
-import fs from "fs";
+import path from "node:path";
+import fs from "node:fs";
+import { getFormattedDate } from "../utils/date.js";
 
 const uploadFolder = path.resolve(process.cwd(), "uploads");
 
@@ -13,7 +14,7 @@ const storage = multer.diskStorage({
         cb(null, uploadFolder);
     },
     filename: (req, file, cb) => {
-        const uniqueName = `${Date.now()}-${file.originalname}`;
+        const uniqueName = `${getFormattedDate()}_${file.originalname}`;
         cb(null, uniqueName);
     },
 });

--- a/server/node-server-app/src/utils/date.js
+++ b/server/node-server-app/src/utils/date.js
@@ -1,0 +1,17 @@
+function getFormattedDate() {
+    const now = new Date();
+
+    const year = now.getFullYear(); 
+    const month = String(now.getMonth() + 1).padStart(2, "0"); 
+    const day = String(now.getDate()).padStart(2, "0"); 
+
+    const hour = String(now.getHours()).padStart(2, "0"); 
+    const minute = String(now.getMinutes()).padStart(2, "0");
+    const second = String(now.getSeconds()).padStart(2, "0");
+
+    const formattedDate = `${year}_${month}_${day}_${hour}_${minute}_${second}`;
+
+    return formattedDate;
+}
+
+export { getFormattedDate };

--- a/server/node-server-app/tests-jest/utils/date.test.js
+++ b/server/node-server-app/tests-jest/utils/date.test.js
@@ -1,0 +1,13 @@
+import { getFormattedDate } from "../../src/utils/date.js";
+
+describe("getFormattedDate", () => {
+    test("should return date in YYYY_MM_DD_HH_MM_SS format", () => {
+        const result = getFormattedDate();
+
+        expect(result).toMatch(/^\d{4}_\d{2}_\d{2}_\d{2}_\d{2}_\d{2}$/);
+
+        const currentYear = new Date().getFullYear();
+        
+        expect(result.startsWith(currentYear.toString())).toBe(true);
+    });
+});


### PR DESCRIPTION
closes #142 

- The utility ensures all file names use a consistent, readable pattern YYYY_MM_DD_HH_MM_SS
- which is going to be used by the upload middleware for naming uploaded files.


<img width="351" height="177" alt="image" src="https://github.com/user-attachments/assets/7ca4d07b-bb01-47e3-b527-f1d8c31b7cea" />
