### PR TITLE
be: add filename sanitization utility for safe uploads | closes #143

### DIFF
--- a/server/node-server-app/package-lock.json
+++ b/server/node-server-app/package-lock.json
@@ -64,6 +64,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2205,6 +2206,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2368,7 +2370,8 @@
     "node_modules/append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
-      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
     },
     "node_modules/append-transform": {
       "version": "2.0.0",
@@ -2630,9 +2633,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.23",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.23.tgz",
-      "integrity": "sha512-616V5YX4bepJFzNyOfce5Fa8fDJMfoxzOIzDCZwaGL8MKVpFrXqfNUoIpRn9YMI5pXf/VKgzjB4htFMsFKKdiQ==",
+      "version": "2.8.24",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.24.tgz",
+      "integrity": "sha512-uUhTRDPXamakPyghwrUcjaGvvBqGrWvBHReoiULMIpOJVM9IYzQh83Xk2Onx5HlGI2o10NNCzcs9TG/S3TkwrQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2734,6 +2737,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -3232,6 +3236,7 @@
       "engines": [
         "node >= 6.0"
       ],
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -3650,6 +3655,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6077,6 +6083,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6108,6 +6115,7 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -6125,6 +6133,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
       "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
         "busboy": "^1.6.0",
@@ -6142,6 +6151,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -6150,6 +6160,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -6158,6 +6169,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -6169,6 +6181,7 @@
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -6973,6 +6986,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -7405,6 +7419,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -7959,6 +7974,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -8397,7 +8413,8 @@
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -8517,7 +8534,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "8.3.2",

--- a/server/node-server-app/package.json
+++ b/server/node-server-app/package.json
@@ -12,6 +12,7 @@
     "test:jest": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" ./node_modules/.bin/jest --runInBand",
     "test:ava": "./node_modules/.bin/ava \"tests-ava/**/*.js\"",
     "test": "npm run test:jest",
+    "test:jest:watch": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" ./node_modules/.bin/jest --runInBand --watch",
     "cover:nyc": "echo \"not working\"",
     "cover:jest": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" ./node_modules/.bin/jest --runInBand --coverage",
     "cover": "npm run cover:jest",

--- a/server/node-server-app/src/utils/sanitize.js
+++ b/server/node-server-app/src/utils/sanitize.js
@@ -1,41 +1,77 @@
+
 /**
- * Sanitize filename
- * @param {string} originalName - original filename
- * @returns {string} sanitized filename
+ * collapse consecutive spaces
+ * @param {string|String} input
+ * @param {{preserveLineBreaks: boolean, maxChars: number, countCodePoints: boolean}} options
+ * @returns {string}
  */
-function sanitizeFilename(originalName) {
-    if (!originalName || typeof originalName !== "string") {
-        throw new Error("Invalid filename input");
+function removeConsecutiveSpaces(input, options = { preserveLineBreaks: false, maxChars: 1024, countCodePoints: true }) {
+    if (input === undefined || input === null) {
+        throw new TypeError("Param input should be a string.");
     }
-
-    let name = originalName.toLowerCase();
-
-    name = name.replace(/\s+/g, " ");
-    name = name.trim();
-    name = name.replace(/\s/g, "_");
-    name = name.replace(/[^\u0020-\u007E]/g, "");
-
-    const parts = name.split(".");
-    const compoundExtensions = ["tar.gz", "tar.bz2", "tar.xz"];
-    const lastTwo = parts.slice(-2).join(".");
-
-    if (compoundExtensions.includes(lastTwo)) {
-        const base = parts.slice(0, -2).join("_");
-        name = `${base}.${lastTwo}`;
-    } else if (parts.length > 2) {
-        const ext = parts.pop();
-        name = parts.join("_") + "." + ext;
+    const str = String(input);
+    const max = options.maxChars ?? 1024;
+    const length = options.countCodePoints ? [...str].length : str.length;
+    if (length === 0) {
+        return str;
     }
-    name = name.replace(/[^a-z0-9._-]/g, "_");
-    name = name.replace(/_+/g, "_");
-
-    if (name.startsWith(".") && !name.startsWith("..")) {
-        return name;
+    if (length > max) {
+        throw new RangeError("Param input is too long. (1024+)");
     }
-
-    name = name.replace(/^_+|_+$/g, "").replace(/_+\./g, ".");
-
-    return name;
+    if (options.preserveLineBreaks) {
+        // remove line spaces except line endings
+        return str.trim().replace(/[^\S\r\n]+/g, " ");
+    }
+    // default: remove all whitespace
+    return str.trim().replace(/\s+/g, " ");
 }
 
-export { sanitizeFilename };
+/**
+ * Sanitize filename
+ * @param {string} input - original filename
+ * @returns {string} sanitized filename
+ */
+function sanitizeFilename(input, options = { maxChars: 255, countCodePoints: true }) {
+    if (input === undefined || input === null) {
+        return "_";
+    }
+    input = String(input);
+    input = removeConsecutiveSpaces(input);
+
+    // limit to 255 code points (avoid breaking surrogate pairs)
+    const MAX = options.maxChars;
+    if (options.countCodePoints) {
+        input = [...input].slice(0, MAX).join("");
+    } else {
+        input = input.slice(0, MAX).join("");
+    }
+
+    const hasLeadingDot = input.startsWith(".");
+
+    const parts = input
+        .toLowerCase()
+        .split(".")
+        .map(part =>
+            part
+                .replace(/[^a-z0-9_-]+/g, "_")
+                .replace(/_+/g, "_")
+                .replace(/^_+|_+$/g, "")
+        )
+        .filter(Boolean);
+
+    let out = parts.join(".");
+
+    if (hasLeadingDot && out) {
+        out = "." + out;
+    } else if (hasLeadingDot && !out) {
+        out = ".";
+    }
+
+    if (!out) {
+        return "_";
+    }
+
+    return out;
+}
+
+export { sanitizeFilename, removeConsecutiveSpaces };

--- a/server/node-server-app/tests-jest/sanitize.test.js
+++ b/server/node-server-app/tests-jest/sanitize.test.js
@@ -1,13 +1,5 @@
-import { sanitizeFilename } from "../src/utils/sanitize.js";
-import { test, beforeEach, afterEach, expect, jest } from "@jest/globals";
-
-beforeEach(() => {
-    jest.restoreAllMocks();
-});
-
-afterEach(() => {
-    jest.restoreAllMocks();
-});
+import { removeConsecutiveSpaces, sanitizeFilename } from "../src/utils/sanitize.js";
+import { test, expect, describe, it } from "@jest/globals";
 
 test("sanitizeFilename converts uppercase to lowercase", () => {
     const result = sanitizeFilename("MyFile.JPG");
@@ -34,13 +26,36 @@ test("sanitizeFilename keeps hidden files like .env as-is", () => {
     expect(result).toBe(".env");
 });
 
-test("sanitizeFilename throws error for invalid input", () => {
-    expect(() => sanitizeFilename(null)).toThrow("Invalid filename input");
-    expect(() => sanitizeFilename(undefined)).toThrow("Invalid filename input");
-    expect(() => sanitizeFilename(123)).toThrow("Invalid filename input");
-});
-
 test("sanitizeFilename handles mixed special cases together", () => {
     const result = sanitizeFilename("Test@File(1).tar.gz");
     expect(result).toBe("test_file_1.tar.gz");
+});
+
+test("sanitizeFilename fails", () => {
+    const actual = sanitizeFilename("___file  _  name . . .env");
+    const expected = "file_name.env";
+    expect(actual).toBe(expected);
+});
+
+test("sanitizeFilename doesn't throw error if it is longer than expected", () => {
+    expect(sanitizeFilename("a".repeat(256))).toBe("a".repeat(255));
+});
+
+describe("removeConsecutiveSpaces", () => {
+    it("should remove consecutive spaces and convert to single space", () => {
+        const input = "wha  t   is     going   on with    space      s   ?";
+        const actual = removeConsecutiveSpaces(input);
+        const expected = "wha t is going on with space s ?";
+        expect(actual).toBe(expected);
+    });
+    it("should return string as it is when there are no spaces", () => {
+        const input = "ThereAreNoSpaces!";
+        const actual = removeConsecutiveSpaces(input);
+        const expected = "ThereAreNoSpaces!";
+        expect(actual).toBe(expected);
+    });
+
+    it("should throw error if the input is 1025 characters long", () => {
+        expect(() => removeConsecutiveSpaces("a".repeat(1025))).toThrow("Param input is too long. (1024+)");
+    });
 });


### PR DESCRIPTION
closes #143 


### why these was needed:
- Unsanitized filenames can cause issues such as:
   - Filesystem write errors (due to invalid characters)
   - Collisions from duplicate or unsafe names
   - Inconsistent naming in uploads and logs

- Added new test suite: `tests-jest/sanitize.test.js`
  - Covers valid, invalid, and edge-case scenarios
  - Ensures consistent behavior and lint compliance

###  How it was tested
- Ran Jest unit tests locally  
  ```bash
  npm test -- tests-jest/sanitize.test.js


<img width="943" height="201" alt="image" src="https://github.com/user-attachments/assets/2866299f-cbe1-43d2-b6c4-8ce474800368" />
