### PR TITLE
fix: pre-commit bug | Fixes #130

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail
-
 echo "Running lint before commit..."
 
 # Move to repo root
@@ -26,3 +24,4 @@ fi
 
 echo "✅ Lint passed — proceeding with commit."
 exit 0
+


### PR DESCRIPTION
Refer to 
- #130 
- #33 

---

Put this code in file `.git/hooks/pre-commit`

```bash
#!/usr/bin/env bash

set -euxo pipefail

bash scripts/pre-commit.sh
```

The scripts/pre-commit has the updated code..


After this there shouldn't be any issues with pre-commit hook.

Warning: the script execution is noisy; we might remove `x` from `-euxo pipefail`

<img width="1195" height="470" alt="chatgpt says so..." src="https://github.com/user-attachments/assets/deb85952-1fea-4b26-9336-d3924f940a3a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved pre-commit validation to run both server and client lint checks and consolidate results.
  * Enhanced error handling and clearer success/failure messages to make pre-commit outcomes more visible.
  * Ensures linting runs from the repository root for more consistent behavior across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->