### PR TITLE
fe: implement debounced network request and added tests

### DIFF
--- a/client/react-client-app/src/net/auth.js
+++ b/client/react-client-app/src/net/auth.js
@@ -1,8 +1,9 @@
 import { readCookie } from "../utils/cookie.js";
 import { CONF } from "./net-conf.js";
+import { debounce } from "../utils/debounce.js";
 
-async function prelogin() {
-    const res = await fetch(`${CONF.HTTPS_SERVER}/${CONF.URLS.LOGIN}`, {
+const _prelogin = async function () {
+    return fetch(`${CONF.HTTPS_SERVER}/${CONF.URLS.LOGIN}`, {
         credentials: "include",
         method: "GET",
         headers: {
@@ -10,11 +11,16 @@ async function prelogin() {
             "Content-Type": "application/json",
         },
     });
-    return res;
+};
+
+const preloginDebouncer = debounce(_prelogin, 400);
+
+function prelogin() {
+    return preloginDebouncer();
 }
 
-async function presignup() {
-    const res = await fetch(`${CONF.HTTPS_SERVER}/${CONF.URLS.SIGNUP}`, {
+const _presignup = async function () {
+    return fetch(`${CONF.HTTPS_SERVER}/${CONF.URLS.SIGNUP}`, {
         credentials: "include",
         method: "GET",
         headers: {
@@ -22,8 +28,14 @@ async function presignup() {
             "Content-Type": "application/json",
         }
     });
-    return res;
+};
+
+const presignupDebouncer = debounce(_presignup, 400);
+
+function presignup() {
+    return presignupDebouncer();
 }
+
 
 async function login({ username, password }) {
     return fetch(`${CONF.HTTPS_SERVER}/${CONF.URLS.LOGIN}`, {

--- a/client/react-client-app/src/net/net-conf.js
+++ b/client/react-client-app/src/net/net-conf.js
@@ -1,5 +1,3 @@
-
-
 const CONF = {
     HTTP_SERVER: "http://localhost:9006",
     HTTPS_SERVER: import.meta.env.VITE_API_URL,

--- a/client/react-client-app/src/net/userAccount.js
+++ b/client/react-client-app/src/net/userAccount.js
@@ -1,11 +1,12 @@
 import { CONF } from "./net-conf.js";
+import { debounce }from "../utils/debounce.js";
 
 /**
  *
  * @param {{username: string}} options
  * @returns {Promise<{username: string, createdAt: string, modifiedAt: string}>}
  */
-async function userAccount({ username }) {
+const _userAccount = async function ({ username }) {
     try {
         return await (await fetch(`${CONF.HTTPS_SERVER}/${CONF.URLS.USER_ACCOUNT}`, {
             credentials: "include",
@@ -20,6 +21,12 @@ async function userAccount({ username }) {
         console.error(err);
         return { ok: false };
     }
+};
+
+const userAccountDebouncer = debounce(_userAccount, 400);
+
+function userAccount(options) {
+    return userAccountDebouncer(options);
 }
 
 export {

--- a/client/react-client-app/src/net/userAccount.test.js
+++ b/client/react-client-app/src/net/userAccount.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { userAccount } from "../net/userAccount.js";
+import { CONF } from "../net/net-conf.js";
+
+describe("Debounced userAccount", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+
+        globalThis.fetch = vi.fn(() =>
+            Promise.resolve({
+                json: () => Promise.resolve({ ok: true })
+            })
+        );
+    });
+
+    it("calls fetch only once after 400ms delay", async () => {
+        userAccount({ username: "test1" }).catch(() => {});
+        userAccount({ username: "test2" }).catch(() => {});
+        userAccount({ username: "test3" }).catch(() => {});
+
+        expect(fetch).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(399);
+        expect(fetch).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(1);
+        expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes the last argument to the debounced function", async () => {
+        userAccount({ username: "A" }).catch(() => {});
+        userAccount({ username: "B" }).catch(() => {});
+        userAccount({ username: "C" }).catch(() => {});
+
+        vi.advanceTimersByTime(400);
+
+        expect(fetch).toHaveBeenCalledWith(
+            `${CONF.HTTPS_SERVER}/${CONF.URLS.USER_ACCOUNT}`,
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({ username: "C" }) // correct
+            })
+        );
+    });
+});

--- a/client/react-client-app/src/utils/debounce.js
+++ b/client/react-client-app/src/utils/debounce.js
@@ -1,0 +1,31 @@
+function debounce(fn, delay = 400) {
+  let timer = null;
+  let pendingReject = null;
+
+  return function (...args) {
+    if (pendingReject) {
+      pendingReject(new Error("Previous debounced cancelled"));
+      pendingReject = null;
+    }
+
+    clearTimeout(timer);
+
+    return new Promise((resolve, reject) => {
+      pendingReject = reject;
+
+      timer = setTimeout(async () => {
+        try {
+          const result = await fn(...args);
+          resolve(result);
+        } catch (err) {
+          reject(err);
+        } finally {
+          timer = null;
+          pendingReject = null;
+        }
+      }, delay);
+    });
+  };
+}
+
+export { debounce };

--- a/client/react-client-app/src/utils/debounce.test.js
+++ b/client/react-client-app/src/utils/debounce.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { debounce } from "./debounce.js";
+
+describe("debounce() (Beginner Friendly Tests)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("runs only the last call after the delay", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 500);
+
+    debounced("A").catch(() => {});
+    debounced("B").catch(() => {});
+    debounced("C").catch(() => {});
+
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(500);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("C");
+  });
+
+  it("resets timer every time run() is called", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 300);
+
+    debounced("first").catch(() => {});
+    vi.advanceTimersByTime(200);
+
+    debounced("second").catch(() => {});
+    vi.advanceTimersByTime(200);
+
+    debounced("third").catch(() => {});
+    vi.advanceTimersByTime(299);
+
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("third");
+  });
+
+  it("passes all arguments correctly to the function", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 200);
+
+    debounced("test", 25, "swarg").catch(() => {});
+
+    vi.advanceTimersByTime(200);
+
+    expect(fn).toHaveBeenCalledWith("test", 25, "swarg");
+  });
+});


### PR DESCRIPTION
closes #228

- Added Debounce utility 
- Applied 400ms debounce to auth and userAccount
- Prevents redundant /net requests in quick succession
- Added Vitest tests for Debounce and userAccount

<img width="633" height="324" alt="image" src="https://github.com/user-attachments/assets/64391c21-016e-4568-a8b3-c72321082f3f" />
<img width="1215" height="262" alt="image" src="https://github.com/user-attachments/assets/3d8e4538-7b98-47b6-b02f-b72cf43436ea" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable debounce utility and applied it to pre-login, pre-signup, and account lookup flows to reduce duplicate requests.

* **Behavior Changes**
  * Public calls now route through debounced runners (responses may be delayed by ~400ms).
  * Account lookup signature now accepts a generic options object; prelogin/presignup return debounced results.

* **Tests**
  * Added tests covering the debounce utility and debounced API behavior.

* **Chores**
  * Minor formatting cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->