### PR TITLE
security/fix: using _token in get response

### DIFF
--- a/client/react-client-app/src/actions/authActions.js
+++ b/client/react-client-app/src/actions/authActions.js
@@ -1,12 +1,45 @@
 import { login, signup, logout, prelogin, presignup } from "../net/auth";
 import { user_session } from "../session";
 
+/**
+ *
+ * @returns {Promise<{ok:true}|{ok:false,message:string}>}
+ */
 async function preLoginAction() {
-    await prelogin();
+    try {
+        const result = await prelogin();
+        if (result.ok) {
+            user_session.store("login_token", result.token);
+        } else {
+            result.message = "Cannot fetch login_token. Check Server.";
+        }
+        delete result.token;
+        return result;
+    }
+    catch (err) {
+        console.error(err);
+        return { ok: false, message: err.message };
+    }
 }
 
+/**
+ *
+ * @returns {Promise<{ok:true}|{ok:false,message:string}>}
+ */
 async function preSignupAction() {
-    await presignup();
+    try {
+        const result = await presignup();
+        if (result.ok) {
+            user_session.store("signup_token", result.token);
+        } else {
+            result.message = "Cannot fetch signup_token. Check Server.";
+        }
+        delete result.token;
+        return result;
+    } catch (err) {
+        console.error(err);
+        return { ok: false, message: err.message };
+    }
 }
 
 /**
@@ -18,8 +51,9 @@ async function loginAction({ username, password }) {
     if (!username || !password) {
         return Promise.reject("Username and password are required");
     }
-    const result = await login({ username, password });
-    // console.log(JSON.stringify({ actionResult: result }), null, 4);
+    const token = user_session.retrieve("login_token");
+    user_session.eject("login_token");
+    const result = await login({ username, password, token });
     if (result.ok) {
         user_session.store("username", result.login.username);
         user_session.store("session", result.login.session);
@@ -27,6 +61,8 @@ async function loginAction({ username, password }) {
     }
 
     // failed login
+    // refetching token when action fails
+    await preLoginAction();
     user_session.eject("username");
     console.error(result.error);
     return false;
@@ -41,7 +77,15 @@ async function signupAction({ username, password }) {
     if (!username || !password) {
         return Promise.reject("Username and password are required");
     }
-    return await signup({ username, password });
+    const token = user_session.retrieve("signup_token");
+    user_session.eject("signup_token");
+    const result = await signup({ username, password, token });
+    if (result.ok) {
+        return result;
+    }
+    // refetching token when action fails
+    await preSignupAction();
+    return result;
 }
 
 /**
@@ -49,7 +93,6 @@ async function signupAction({ username, password }) {
  * @returns {Promise<{ok: boolean, logout: boolean, message: string}>}
  */
 async function logoutAction() {
-
     const usernameInSession = user_session.retrieve("username");
     if (!usernameInSession) {
         throw new Error("Username not found!");

--- a/client/react-client-app/src/features/Login.jsx
+++ b/client/react-client-app/src/features/Login.jsx
@@ -25,6 +25,8 @@ function Login({ onLogin }) {
     const [fromSignup, _] = useState(location.retrieve("path")?.endsWith("#signup:true") || false);
     const [failedLogin, setFailedLogin] = useState(false);
 
+    const [preloginError, setPreloginError] = useState("");
+
     function updateLoginPassword(password) {
         if (!password) {
             return;
@@ -53,7 +55,12 @@ function Login({ onLogin }) {
     useEffect(() => {
         (async function () {
             if (!hasUserSession()) {
-                await preLoginAction();
+                const result = await preLoginAction();
+                if (!result.ok) {
+                    setPreloginError(result.message);
+                } else {
+                    setPreloginError("");
+                }
             }
         })();
     }, []);
@@ -68,6 +75,8 @@ function Login({ onLogin }) {
 
     return (<div className="form login vflex">
         <h2>Login</h2>
+
+        {preloginError && <ServiceError hasError={true} message={preloginError}></ServiceError>}
         {failedLogin && <ServiceError hasError={true} message="login failed"></ServiceError>}
         {fromSignup && <p style={{ color: "green" }}>Signup was successful!</p>}
         <div>

--- a/client/react-client-app/src/features/Signup.jsx
+++ b/client/react-client-app/src/features/Signup.jsx
@@ -2,10 +2,12 @@ import { useState, useEffect } from "react";
 import { hasUserSession } from "../utils/session";
 import { preSignupAction } from "../actions/authActions";
 import { Link } from "../components/Link";
+import { ServiceError } from "../components/Error";
 
 function Signup({ onSignup }) {
     const [signup_password, set_signup_password] = useState("");
     const [signup_username, set_signup_username] = useState("");
+    const [presignupError, setPresignupError] = useState("");
 
     function updateSignupPassword(password) {
         if (!password) {
@@ -30,13 +32,19 @@ function Signup({ onSignup }) {
     useEffect(() => {
         (async function () {
             if (!hasUserSession()) {
-                await preSignupAction();
+                const result = await preSignupAction();
+                if (!result.ok) {
+                    setPresignupError(result.message);
+                } else {
+                    setPresignupError("");
+                }
             }
         })();
     }, []);
 
     return (<div className="form signup vflex">
         <h2>Signup</h2>
+        {presignupError && <ServiceError hasError={true} message={presignupError}></ServiceError>}
         <div>
             <label htmlFor="signup_username" className="vflex">
                 <>Username</>

--- a/client/react-client-app/src/net/auth.js
+++ b/client/react-client-app/src/net/auth.js
@@ -1,4 +1,3 @@
-import { readCookie } from "../utils/cookie.js";
 import { CONF } from "./net-conf.js";
 
 /**
@@ -14,7 +13,7 @@ async function prelogin() {
             "Content-Type": "application/json",
         },
     });
-    return res;
+    return res.json();
 }
 
 /**
@@ -30,15 +29,15 @@ async function presignup() {
             "Content-Type": "application/json",
         }
     });
-    return res;
+    return res.json();
 }
 
 /**
  * POST /login
- * @param {{username: string, password: string}} userCredentials
+ * @param {{username: string, password: string, token: string}} userCredentials
  * @returns {Promise<{ok: boolean, login: {username: string, session: string}, message: string}>}
  */
-async function login({ username, password }) {
+async function login({ username, password, token }) {
     const response = await fetch(`${CONF.HTTPS_SERVER}/${CONF.URLS.LOGIN}`, {
         credentials: "include",
         method: "POST",
@@ -46,17 +45,17 @@ async function login({ username, password }) {
             "Accept": "application/json",
             "Content-Type": "application/json",
         },
-        body: JSON.stringify({ username, password, token: readCookie("login_token") }),
+        body: JSON.stringify({ username, password, token }),
     });
-    return await response.json();
+    return response.json();
 }
 
 /**
  * POST /signup
- * @param {{username: string, password: string}} userCredentials
+ * @param {{username: string, password: string, token: string}} userCredentials
  * @returns {Promise<{ok:boolean,signup:{username:string},message:string}>}
  */
-async function signup({ username, password }) {
+async function signup({ username, password, token }) {
     const response = await fetch(`${CONF.HTTPS_SERVER}/${CONF.URLS.SIGNUP}`, {
         credentials: "include",
         method: "POST",
@@ -64,9 +63,9 @@ async function signup({ username, password }) {
             "Accept": "application/json",
             "Content-Type": "application/json",
         },
-        body: JSON.stringify({ username, password, token: readCookie("signup_token") }),
+        body: JSON.stringify({ username, password, token }),
     });
-    return await response.json();
+    return response.json();
 }
 
 /**
@@ -85,7 +84,7 @@ async function logout({ username }) {
         body: JSON.stringify({ username })
     });
 
-    return await response.json();
+    return response.json();
 }
 
 export { login, signup, logout, prelogin, presignup };

--- a/server/node-server-app/src/handlers/authHandler.js
+++ b/server/node-server-app/src/handlers/authHandler.js
@@ -24,9 +24,10 @@ async function signupHandlerGET(req, res) {
     const token = uuidv4();
     res.cookie("signup_token", token, {
         sameSite: "strict",
-        httpOnly: false,
-        secure: false,
-        maxAge: 2 * 60 * 1000
+        httpOnly: true,
+        secure: true,
+        maxAge: 2 * 60 * 1000,
+        path: "/",
     });
     await tokenStore.store(token, (new Date()).toUTCString());
     res.status(200).json({ ok: true, token });
@@ -61,9 +62,10 @@ async function loginHandlerGET(req, res) {
     const token = uuidv4();
     res.cookie("login_token", token, {
         sameSite: "strict",
-        httpOnly: false,
-        secure: false,
-        maxAge: 2 * 60 * 1000
+        httpOnly: true,
+        secure: true,
+        maxAge: 2 * 60 * 1000,
+        path: "/",
     });
     await tokenStore.store(token, (new Date()).toUTCString());
     res.json({ ok: true, token });


### PR DESCRIPTION
1. using token sent by login and signup GET respose body.
2. Using {login|signup}_token
3. Showing error, when the network is not reachable by client in case of new server certificates.

Take a look at the fixed screenshots:
- https://github.com/wtasg/meetonline/issues/303#issuecomment-3615424402
- https://github.com/wtasg/meetonline/issues/303#issuecomment-3615485743