### PR TITLE
ci: enforce standard PR branch names via GitHub Actions

### DIFF
--- a/.github/workflows/enforce-branch-name.yml
+++ b/.github/workflows/enforce-branch-name.yml
@@ -1,0 +1,104 @@
+name: "Enforce PR branch name"
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  BRANCH_PATTERN: "^[A-Za-z][A-Za-z0-9_-]+$"
+  MODE: "block"
+  BOT_IDENTIFIER: "branch-name-enforcer"
+
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const pattern = new RegExp(process.env.BRANCH_PATTERN);
+            const mode = process.env.MODE || 'block';
+            const botId = process.env.BOT_IDENTIFIER || 'branch-name-enforcer';
+
+            const pr = github.context.payload.pull_request;
+            if (!pr) {
+              core.info('No pull_request object on the event, exiting.');
+              return;
+            }
+
+            const headRef = pr.head.ref;
+            core.info(`PR #${pr.number} head ref: ${headRef}`);
+            const ok = pattern.test(headRef);
+
+            const failureMessage = `:x: **Branch name not allowed**
+              The PR's source branch \`${headRef}\` does not match the required pattern:
+              \`\`\`
+              ${process.env.BRANCH_PATTERN}
+              \`\`\`
+
+              Allowed characters: letters, digits, underscore (_), hyphen (-). **No slashes (/) or emoji** by default.
+
+              **How to fix:** rename your branch locally and push the new name, then update the PR (or open a new PR).
+
+              Example rename commands:
+              \`\`\`bash
+              git branch -m "${headRef}" new-branch-name
+              git push origin new-branch-name
+              git push origin --delete "${headRef}"
+              \`\`\`
+
+              If you believe this is a false positive, please contact the maintainers.
+              `;
+            const body = ok
+              ? `Branch name \`${headRef}\` matches required pattern.`
+              : failureMessage;
+
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              per_page: 100
+            });
+
+            const botComment = comments.data.find(c => c.user && c.user.type === 'Bot' && c.body && c.body.includes(botId));
+
+            if (!ok) {
+              const commentBody = `<!-- ${botId} -->\n${body}`;
+              if (botComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: botComment.id,
+                  body: commentBody
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: commentBody
+                });
+              }
+
+              if (mode === 'block') {
+                core.setFailed(`Branch name "${headRef}" does not match pattern ${process.env.BRANCH_PATTERN}`);
+              } else {
+                core.info(`(WARN) Branch name invalid, but MODE=${mode} so not failing the job.`);
+              }
+            } else {
+              if (botComment) {
+                const okBody = `<!-- ${botId} -->\n${body}`;
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: botComment.id,
+                  body: okBody
+                });
+              }
+              core.info('Branch name valid.');
+            }

--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ docker compose --file compose.yml down
 # docker volume list | grep meetonline | awk '{print $2}' | xargs -n1 docker volume rm
 ```
 
+## Branch naming rules
+
+- Repository enforces branch naming pattern: `^[A-Za-z][A-Za-z0-9_-]+$`.
+- Allowed characters: ASCII letters, digits, hyphen (-), underscore (_).
+- Not allowed: slashes (/), emoji, spaces, other non-ASCII characters.
+
+- If your PR fails the branch-name check, rename the branch locally:
+
+```bash
+git branch -m old-name new-name
+git push origin new-name
+git push origin --delete old-name
+```
+
 ## Documentation
 
 Documentation is available in `docs/`. Visit [Documentation Home](./docs/Home.md)


### PR DESCRIPTION
closes #324 

### Summary
This PR introduces a GitHub Actions workflow to enforce standardized branch naming for all pull requests. The workflow ensures branch names conform to the repository’s required pattern and prevents merges from branches that do not meet the policy.

### Logic Implemented
- Validate PR source branch names against the pattern:
  `^[A-Za-z][A-Za-z0-9_-]+$`
-  Post or update a single bot comment when a branch name violates the policy.
- Provide guidance for renaming branches.
- Fail the workflow (in block mode) to prevent merging via branch protection.

### **Why `pull_request_target` instead of `pull_request`**

-`pull_request_target` executes workflows with the correct permission scope for:
 -  adding PR comments
  -  updating comments
  - failing checks
- `pull_request` does **not** have sufficient permissions for fork-based PRs, preventing comment creation and reducing enforcement reliability.

### Outcome*
- Consistent branch naming across contributors
- Improved PR hygiene and review quality
- Reliable enforcement through CI with clear contributor feedback.

