### PR TITLE
Potential fix for code scanning alert no. 24: Missing rate limiting

### DIFF
--- a/server/node-server-app/src/handlers/oauthHandler.js
+++ b/server/node-server-app/src/handlers/oauthHandler.js
@@ -53,7 +53,7 @@ function setupOAuthHandlers(app) {
     // Callback routes
     const providers = ["google", "microsoft", "facebook", "apple"];
     providers.forEach(provider => {
-        app.get(`/oauth/${provider}/callback`, (req, res, next) => {
+        app.get(`/oauth/${provider}/callback`, authRateLimiter, (req, res, next) => {
             const authOptions = { session: false, failWithError: true };
 
             passport.authenticate(provider, authOptions, async (err, result, info) => {


### PR DESCRIPTION
Potential fix for [https://github.com/wtasg/meetonline/security/code-scanning/24](https://github.com/wtasg/meetonline/security/code-scanning/24)

In general, the fix is to ensure that any route performing authentication/authorization or other expensive operations is protected by a rate‑limiting middleware. This project already defines an `authRateLimiter` in `../middlewares/rateLimitMiddleware.js` and uses it for the OAuth initiation endpoints, so the most consistent fix is to apply the same middleware to the OAuth callback endpoints.

Concretely, in `server/node-server-app/src/handlers/oauthHandler.js`, within `setupOAuthHandlers`, the `providers.forEach` block defines `app.get(`/oauth/${provider}/callback`, (req, res, next) => { ... })` without any middleware. We should modify this so that `authRateLimiter` is passed as a middleware argument: `app.get(`/oauth/${provider}/callback`, authRateLimiter, (req, res, next) => { ... })`. No other behavior inside the handler needs to change, and no new imports are necessary because `authRateLimiter` is already imported at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
